### PR TITLE
feat(errors): create issue for dependency lookup failures, fix non-zero exit

### DIFF
--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   raiseConfigWarningIssue,
   raiseCredentialsWarningIssue,
+  raiseDependencyLookupWarningsIssue,
   raiseRepositoryErrorIssue,
 } from './error-config.ts';
 
@@ -148,6 +149,142 @@ Message: some-message
       expect(logger.info).toHaveBeenCalledWith(
         { notificationName },
         'Configuration failure, issues will be suppressed',
+      );
+    });
+  });
+
+  describe('raiseDependencyLookupWarningsIssue()', () => {
+    beforeEach(() => {
+      GlobalConfig.reset();
+    });
+
+    const packageFilesWithWarnings = {
+      nix: [
+        partial({
+          packageFile: 'flake.nix',
+          deps: [
+            partial({
+              warnings: [
+                {
+                  topic: 'https://github.com/foo/bar',
+                  message:
+                    'Dependency lookup error for `git-refs` package `https://github.com/foo/bar`: Repository not found.',
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    };
+
+    it('returns if mode is silent', async () => {
+      config.mode = 'silent';
+      await raiseDependencyLookupWarningsIssue(config, {});
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Dependency lookup warning issues are not created, updated or closed when mode=silent',
+      );
+      expect(platform.ensureIssue).not.toHaveBeenCalled();
+    });
+
+    it('suppresses issue when suppressNotifications includes dependencyLookupWarnings', async () => {
+      config.suppressNotifications = ['dependencyLookupWarnings'];
+      await raiseDependencyLookupWarningsIssue(
+        config,
+        packageFilesWithWarnings,
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        { notificationName: 'dependencyLookupWarnings' },
+        'Dependency lookup warnings, issues will be suppressed',
+      );
+      expect(platform.ensureIssue).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there are no warnings', async () => {
+      await raiseDependencyLookupWarningsIssue(config, {});
+      expect(platform.ensureIssue).not.toHaveBeenCalled();
+    });
+
+    it('logs dry-run message instead of creating issue', async () => {
+      GlobalConfig.set({ dryRun: 'full' });
+      await raiseDependencyLookupWarningsIssue(
+        config,
+        packageFilesWithWarnings,
+      );
+      expect(platform.ensureIssue).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ warnings: expect.any(Array) }),
+        'DRY-RUN: Would ensure dependency lookup warning issue',
+      );
+    });
+
+    it('creates issue when there are lookup warnings', async () => {
+      platform.ensureIssue.mockResolvedValueOnce('created');
+      await raiseDependencyLookupWarningsIssue(
+        config,
+        packageFilesWithWarnings,
+      );
+      expect(platform.ensureIssue).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          title: 'Action Required: Fix Dependency Lookup Errors',
+          body: expect.stringContaining('flake.nix'),
+          once: false,
+          shouldReOpen: true,
+        }),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ res: 'created' }),
+        'Dependency Lookup Warning',
+      );
+    });
+
+    it('updates existing issue and logs warning', async () => {
+      platform.ensureIssue.mockResolvedValueOnce('updated');
+      await raiseDependencyLookupWarningsIssue(
+        config,
+        packageFilesWithWarnings,
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ res: 'updated' }),
+        'Dependency Lookup Warning',
+      );
+    });
+
+    it('does not log warning when issue is unchanged', async () => {
+      platform.ensureIssue.mockResolvedValueOnce(null);
+      await raiseDependencyLookupWarningsIssue(
+        config,
+        packageFilesWithWarnings,
+      );
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'Dependency Lookup Warning',
+      );
+    });
+
+    it('normalizes newlines in warning messages', async () => {
+      platform.ensureIssue.mockResolvedValueOnce('created');
+      const packageFilesWithNewline = {
+        nix: [
+          partial({
+            packageFile: 'flake.nix',
+            deps: [
+              partial({
+                warnings: [
+                  {
+                    topic: 'pkg',
+                    message: 'line one\nline two',
+                  },
+                ],
+              }),
+            ],
+          }),
+        ],
+      };
+      await raiseDependencyLookupWarningsIssue(config, packageFilesWithNewline);
+      expect(platform.ensureIssue).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          body: expect.stringContaining('line one line two'),
+        }),
       );
     });
   });

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -3,10 +3,12 @@ import { GlobalConfig } from '../../config/global.ts';
 import type { RenovateConfig } from '../../config/types.ts';
 import { logger } from '../../logger/index.ts';
 import { sanitizeUrls } from '../../logger/utils.ts';
+import type { PackageFile } from '../../modules/manager/types.ts';
 import type { Pr } from '../../modules/platform/index.ts';
 import { platform } from '../../modules/platform/index.ts';
 import { getInheritedOrGlobal } from '../../util/common.ts';
 import { sanitize } from '../../util/sanitize.ts';
+import { getDepWarnings } from './errors-warnings.ts';
 
 export function raiseConfigWarningIssue(
   config: RenovateConfig,
@@ -147,5 +149,53 @@ async function handleOnboardingPr(pr: Pr, issueMessage: string): Promise<void> {
     });
   } catch (err) /* istanbul ignore next */ {
     logger.warn({ err }, 'Error updating onboarding PR');
+  }
+}
+
+export async function raiseDependencyLookupWarningsIssue(
+  config: RenovateConfig,
+  packageFiles: Record<string, PackageFile[]>,
+): Promise<void> {
+  logger.debug('raiseDependencyLookupWarningsIssue()');
+  if (config.mode === 'silent') {
+    logger.debug(
+      'Dependency lookup warning issues are not created, updated or closed when mode=silent',
+    );
+    return;
+  }
+  const notificationName = 'dependencyLookupWarnings';
+  if (config.suppressNotifications?.includes(notificationName)) {
+    logger.info(
+      { notificationName },
+      'Dependency lookup warnings, issues will be suppressed',
+    );
+    return;
+  }
+  const { warnings, warningFiles } = getDepWarnings(packageFiles);
+  if (!warnings.length) {
+    return;
+  }
+  if (GlobalConfig.get('dryRun')) {
+    logger.info(
+      { warnings },
+      'DRY-RUN: Would ensure dependency lookup warning issue',
+    );
+    return;
+  }
+  const title = `Action Required: Fix Dependency Lookup Errors`;
+  let body = `Renovate failed to look up the following dependencies. Please investigate and fix these issues in your repository.\n\n`;
+  for (const w of warnings) {
+    body += `- \`${w.split('\n').join(' ').trim()}\`\n`;
+  }
+  body += `\nFiles affected: ${warningFiles.map((f) => '`' + f + '`').join(', ')}\n`;
+  const res = await platform.ensureIssue({
+    title,
+    body,
+    once: false,
+    shouldReOpen: true,
+    confidential: config.confidential,
+  });
+  if (res === 'updated' || res === 'created') {
+    logger.warn({ warnings, res }, 'Dependency Lookup Warning');
   }
 }

--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -33,7 +33,7 @@ export function getErrors(config: RenovateConfig): string {
   return errorText;
 }
 
-function getDepWarnings(
+export function getDepWarnings(
   packageFiles: Record<string, PackageFile[]>,
 ): DepWarnings {
   const warnings: string[] = [];

--- a/lib/workers/repository/finalize/index.ts
+++ b/lib/workers/repository/finalize/index.ts
@@ -49,5 +49,8 @@ function ensureIssuesClosing(): Promise<Awaited<void>[]> {
     platform.ensureIssueClosing(
       `Action Required: Fix Renovate Repository Error`,
     ),
+    platform.ensureIssueClosing(
+      `Action Required: Fix Dependency Lookup Errors`,
+    ),
   ]);
 }

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -37,6 +37,7 @@ import { extractRepoProblems } from './common.ts';
 import { configMigration } from './config-migration/index.ts';
 import { ensureDependencyDashboard } from './dependency-dashboard.ts';
 import handleError from './error.ts';
+import { raiseDependencyLookupWarningsIssue } from './error-config.ts';
 import { finalizeRepo } from './finalize/index.ts';
 import { pruneStaleBranches } from './finalize/prune.ts';
 import { initRepo } from './init/index.ts';
@@ -170,6 +171,7 @@ export async function renovateRepository(
           packageFiles,
           configMigrationRes,
         );
+        await raiseDependencyLookupWarningsIssue(config, packageFiles);
       }
       await finalizeRepo(config, branchList, repoConfig);
       // TODO #22198

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -798,7 +798,7 @@ export async function lookupUpdates(
       return Result.err(err);
     }
 
-    logger.error(
+    logger.warn(
       {
         currentDigest: config.currentDigest,
         currentValue: config.currentValue,


### PR DESCRIPTION
- Add raiseDependencyLookupWarningsIssue() which creates/updates a GitHub issue when package lookups fail, so users are notified even when no PR exists or the Dependency Dashboard is not enabled
- Export getDepWarnings() from errors-warnings.ts for reuse
- Wire into renovateRepository() after ensureDependencyDashboard and close the issue in ensureIssuesClosing() when warnings are resolved
- Downgrade lookupUpdates catch-all log from error to warn so handled lookup failures no longer cause a non-zero exit code