### PR TITLE
fix(errors): close lookup warning issue only when all warnings resolved 

### DIFF
--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -199,9 +199,12 @@ Message: some-message
       expect(platform.ensureIssue).not.toHaveBeenCalled();
     });
 
-    it('does nothing when there are no warnings', async () => {
+    it('closes existing issue when there are no warnings', async () => {
       await raiseDependencyLookupWarningsIssue(config, {});
       expect(platform.ensureIssue).not.toHaveBeenCalled();
+      expect(platform.ensureIssueClosing).toHaveBeenCalledExactlyOnceWith(
+        'Action Required: Fix Dependency Lookup Errors',
+      );
     });
 
     it('logs dry-run message instead of creating issue', async () => {

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -173,6 +173,9 @@ export async function raiseDependencyLookupWarningsIssue(
   }
   const { warnings, warningFiles } = getDepWarnings(packageFiles);
   if (!warnings.length) {
+    await platform.ensureIssueClosing(
+      `Action Required: Fix Dependency Lookup Errors`,
+    );
     return;
   }
   if (GlobalConfig.get('dryRun')) {

--- a/lib/workers/repository/finalize/index.ts
+++ b/lib/workers/repository/finalize/index.ts
@@ -49,8 +49,5 @@ function ensureIssuesClosing(): Promise<Awaited<void>[]> {
     platform.ensureIssueClosing(
       `Action Required: Fix Renovate Repository Error`,
     ),
-    platform.ensureIssueClosing(
-      `Action Required: Fix Dependency Lookup Errors`,
-    ),
   ]);
 }


### PR DESCRIPTION
Previously the issue was immediately closed after creation because
ensureIssuesClosing() ran unconditionally at the end of every
successful repo run. Move the close into raiseDependencyLookupWarningsIssue
so it only fires when there are actually no warnings left.