### PR TITLE
fix(nix-update): bump version line in updateDependency

### DIFF
--- a/lib/modules/manager/nix-update/update.spec.ts
+++ b/lib/modules/manager/nix-update/update.spec.ts
@@ -1,21 +1,111 @@
 import { updateDependency } from './update.ts';
 
 describe('modules/manager/nix-update/update', () => {
-  it('returns file content unchanged', () => {
-    const fileContent = 'some nix file content\nwith multiple lines\n';
+  it('bumps `version = "X"` to the new value', () => {
+    const fileContent = `
+      buildGoModule rec {
+        pname = "foo";
+        version = "0.0.60";
+        src = fetchFromGitHub { rev = "v\${version}"; hash = "..."; };
+      }
+    `;
     const result = updateDependency({
       fileContent,
-      packageFile: 'flake.nix',
-      upgrade: { depName: 'foo', currentValue: '0', newValue: '1' },
+      packageFile: 'packages/foo/default.nix',
+      upgrade: {
+        depName: 'foo',
+        currentValue: '0.0.60',
+        newValue: '0.0.61',
+      },
+    });
+    expect(result).toContain('version = "0.0.61";');
+    expect(result).not.toContain('version = "0.0.60";');
+  });
+
+  it('falls back to newVersion when newValue is missing', () => {
+    const result = updateDependency({
+      fileContent: 'version = "1.0";\n',
+      packageFile: 'packages/foo/default.nix',
+      upgrade: {
+        depName: 'foo',
+        currentValue: '1.0',
+        newVersion: '1.1',
+      },
+    });
+    expect(result).toBe('version = "1.1";\n');
+  });
+
+  it('returns content unchanged when currentValue equals newValue (branch-tracked)', () => {
+    const fileContent = 'version = "0-unstable-2025-11-17";\n';
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'packages/foo/default.nix',
+      upgrade: {
+        depName: 'foo',
+        currentValue: 'main',
+        newValue: 'main',
+        currentDigest: 'oldsha',
+        newDigest: 'newsha',
+      },
     });
     expect(result).toBe(fileContent);
+  });
+
+  it('returns content unchanged when neither newValue nor newVersion is set', () => {
+    const fileContent = 'version = "1.0";\n';
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'packages/foo/default.nix',
+      upgrade: { depName: 'foo', currentValue: '1.0' },
+    });
+    expect(result).toBe(fileContent);
+  });
+
+  it('returns content unchanged when version line is not present (already-bumped branch)', () => {
+    // Re-run scenario: branch already has version="0.0.61", currentValue from
+    // extract is still "0.0.60". We don't try to be clever, just no-op.
+    const fileContent = 'version = "0.0.61";\n';
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'packages/foo/default.nix',
+      upgrade: {
+        depName: 'foo',
+        currentValue: '0.0.60',
+        newValue: '0.0.61',
+      },
+    });
+    expect(result).toBe(fileContent);
+  });
+
+  it('does not match `vendorVersion` or other *Version attrs', () => {
+    const fileContent = `
+      version = "1.0";
+      vendorVersion = "1.0";
+    `;
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'packages/foo/default.nix',
+      upgrade: { depName: 'foo', currentValue: '1.0', newValue: '1.1' },
+    });
+    expect(result).toContain('version = "1.1";');
+    expect(result).toContain('vendorVersion = "1.0";');
+  });
+
+  it('handles multi-whitespace version assignment', () => {
+    const fileContent = 'version    =   "0.0.60" ;\n';
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'packages/foo/default.nix',
+      upgrade: { depName: 'foo', currentValue: '0.0.60', newValue: '0.0.61' },
+    });
+    expect(result).toContain('"0.0.61"');
   });
 
   it('returns empty string unchanged', () => {
     const result = updateDependency({
       fileContent: '',
-      packageFile: 'flake.nix',
-      upgrade: { depName: 'foo' },
+      packageFile: 'packages/foo/default.nix',
+      upgrade: { depName: 'foo', currentValue: '1.0', newValue: '1.1' },
     });
     expect(result).toBe('');
   });

--- a/lib/modules/manager/nix-update/update.ts
+++ b/lib/modules/manager/nix-update/update.ts
@@ -1,9 +1,39 @@
+import { escapeRegExp, regEx } from '../../../util/regex.ts';
 import type { UpdateDependencyConfig } from '../types.ts';
 
+// Bump the package's `version = "<currentValue>"` line to the new value.
+// We must do this here (rather than relying on Renovate's `doAutoReplace`)
+// because Renovate skips auto-replace when a manager defines its own
+// `updateDependency`. Hashes are still handled in `updateArtifacts` via the
+// runner-side prefetch — this function is *only* about the version line.
+//
+// Branch-tracked packages (`--version=branch`) keep `currentValue ===
+// newValue` (the branch name), so this is a no-op for them; their version
+// attribute typically encodes a date string we don't have.
 export function updateDependency({
   fileContent,
+  upgrade,
 }: UpdateDependencyConfig): string | null {
-  // No-op: the fake '1' must never be written to any nix file.
-  // nix-update in updateArtifacts handles the real version + hash updates.
-  return fileContent;
+  const { currentValue } = upgrade;
+  // Prefer newValue (datasource-normalised, no `v` prefix) over newVersion
+  // (raw tag — may include the prefix and produce `version = "v1.2.3"`).
+  const newValue = upgrade.newValue ?? upgrade.newVersion;
+  if (!currentValue || !newValue || currentValue === newValue) {
+    return fileContent;
+  }
+  // Match `version = "<currentValue>"` (any whitespace), case-sensitive.
+  // We anchor on `\bversion\s*=\s*` so unrelated `*Version` attrs aren't hit.
+  const versionLine = regEx(
+    `(\\bversion\\s*=\\s*)"${escapeRegExp(currentValue)}"`,
+  );
+  if (!versionLine.test(fileContent)) {
+    // File doesn't contain the expected `version = "<currentValue>"` —
+    // could be: (a) we're re-running on an already-bumped branch, or
+    // (b) the package puts version somewhere unusual. In both cases,
+    // returning fileContent unchanged is safe — updateArtifacts handles
+    // the rest, and Renovate's "no content changed" path falls through
+    // to the nix-update special-case in get-updated.ts.
+    return fileContent;
+  }
+  return fileContent.replace(versionLine, `$1"${newValue}"`);
 }


### PR DESCRIPTION
## Bug

After PR #636 merged and the cluster ran, `kubernetes-mcp-server`'s renovate branch ended up with `version = "0.0.60"` (unchanged) **but** v0.0.61's `src.hash` and `vendorHash` written into the file. The result is unbuildable — the hashes describe v0.0.61 source, but the URL resolves v0.0.60.

## Root cause

`lib/workers/repository/update/branch/get-updated.ts:233-261`: when a manager defines its own `updateDependency`, Renovate calls it **instead of** `doAutoReplace`. Our previous `updateDependency` was a no-op (`return fileContent`), so:

- The `version = "0.0.60"` line never got bumped.
- `updateArtifacts` then ran on the unchanged content, but `bumpFodToNewVersion` correctly used `newValue` to splice v0.0.61 into URL/rev for the prefetch — getting the v0.0.61 hashes.
- `rewriteHash` wrote those v0.0.61 hashes into a file whose `version =` line still said `0.0.60`.

## Fix

`updateDependency` now actually bumps `version = "<currentValue>"` → `version = "<newValue>"`. We:

- Prefer `newValue` (datasource-normalised, no `v` prefix) over `newVersion` to avoid `version = "v0.0.61"` for packages that store bare versions.
- No-op when `currentValue === newValue` (branch-tracked packages).
- No-op when the version line isn't found (re-running on an already-bumped branch — `updateArtifacts` still handles hashes via the existing rewrite path).
- Anchor on `\bversion\s*=\s*` so unrelated `*Version` attrs (e.g. `vendorVersion`) aren't matched.

Hashes remain handled by `updateArtifacts` (runner-side prefetch + rewriteHash) — this PR only adds the version-line bump.

## Tests

8 new unit tests in `update.spec.ts` covering: bump path, `newVersion` fallback, branch-tracked no-op, missing-newValue no-op, already-bumped no-op, `vendorVersion` non-match, multi-whitespace, empty content. Full suite: 209/209 green, 100% coverage on the manager.