### PR TITLE
fix(nix-update): drop --eval-system so prefetch runs on the runner system

### DIFF
--- a/lib/modules/manager/nix-update/artifacts.spec.ts
+++ b/lib/modules/manager/nix-update/artifacts.spec.ts
@@ -187,10 +187,10 @@ describe('modules/manager/nix-update/artifacts', () => {
       config,
     });
 
-    // first exec: src; second exec: vendor (with --eval-system darwin)
+    // first exec: src; second exec: vendor — both use runnerPkgs (no --eval-system)
     expect(snapshots[0].cmd).toContain('runnerPkgs.fetchFromGitHub');
     expect(snapshots[1].cmd).toContain('runnerPkgs.buildGoModule');
-    expect(snapshots[0].cmd).toContain('--eval-system x86_64-darwin');
+    expect(snapshots[0].cmd).not.toContain('--eval-system');
     // vendor expression should reference the now-known src hash, not the placeholder
     expect(snapshots[1].cmd).toContain(NEW_SRC);
   });

--- a/lib/modules/manager/nix-update/extract.ts
+++ b/lib/modules/manager/nix-update/extract.ts
@@ -334,9 +334,9 @@ export async function extractAllPackageFiles(
 
   // Phase 3: iterate every system in .#packages, recording which system each
   // package belongs to. Later systems overwrite earlier ones for cross-platform
-  // packages (any system works). Per-system tracking lets us pass --system to
-  // nix-update so it evaluates Linux-only packages on Linux and macOS-only
-  // packages on macOS, regardless of which system renovate itself runs on.
+  // packages (any system works). The recorded system is passed through to
+  // updateArtifacts purely as a cache-namespacing key — prefetch itself runs
+  // on the runner regardless.
   // Collapse to a single line before JSON.stringify — shell passes the
   // --apply value as-is, so literal \n from JSON escaping would break nix.
   const singleLineExpr = evalExpr.replace(/\n\s*/g, ' ').trim();

--- a/lib/modules/manager/nix-update/prefetch.spec.ts
+++ b/lib/modules/manager/nix-update/prefetch.spec.ts
@@ -120,7 +120,7 @@ describe('modules/manager/nix-update/prefetch', () => {
       ).rejects.toThrow(/unexpectedly succeeded/);
     });
 
-    it('passes --eval-system and the expression to nix-build', async () => {
+    it('does not pass --eval-system so runnerPkgs resolves to the runner system', async () => {
       const stderr =
         '  got: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
       const snapshots = mockExecSequence([makeMismatchError(stderr)]);
@@ -131,9 +131,13 @@ describe('modules/manager/nix-update/prefetch', () => {
       });
       const cmd = snapshots[0].cmd;
       expect(cmd).toContain('nix build');
-      expect(cmd).toContain('--eval-system x86_64-darwin');
       expect(cmd).toContain('--no-link');
       expect(cmd).toContain('--impure');
+      // Critical: passing --eval-system would make `builtins.currentSystem`
+      // resolve to the package's system, then `runnerPkgs` would be darwin
+      // pkgs, then the fetcher would produce a darwin derivation linux
+      // can't build. We rely on currentSystem == runner system.
+      expect(cmd).not.toContain('--eval-system');
       // Multiline expr should have been collapsed.
       expect(cmd).not.toContain('\n');
     });

--- a/lib/modules/manager/nix-update/prefetch.ts
+++ b/lib/modules/manager/nix-update/prefetch.ts
@@ -14,8 +14,9 @@ const base32Regex = regEx(/got:\s+([a-z0-9]{52})/);
 export interface PrefetchOptions {
   // raw nix expression (multi-line OK — we collapse before shell-quoting)
   expr: string;
-  // package's declared system, used for --eval-system to resolve cross-platform
-  // attrs in the expression. Build always runs on the runner.
+  // package's declared system. Not passed to nix-build (see comment in
+  // `prefetch` on why) — used purely to namespace the prefetch cache so
+  // entries from packages declaring different systems don't collide.
   pkgSystem: string;
   // algo of the FOD we're prefetching; used to validate the parsed result.
   algo: HashAlgo;
@@ -109,17 +110,25 @@ export async function prefetch(opts: PrefetchOptions): Promise<string> {
     );
     return cached;
   }
-  // --no-link:    don't pollute cwd with a result symlink.
-  // --eval-system lets the original-package evaluation resolve attrs declared
-  //               only on that system. Build still happens on the runner.
-  // --impure is required because we use `builtins.getFlake "<localPath>"`
-  //          (impure) and may fall back to `import <nixpkgs>`. Doesn't affect
-  //          the FOD hash — the output is still purely a function of the
-  //          fetcher inputs (URL/rev/etc.).
+  // --no-link: don't pollute cwd with a result symlink.
+  // --impure:  required because we use `builtins.getFlake "<localPath>"`
+  //            (impure) and may fall back to `import <nixpkgs>`. Doesn't
+  //            affect the FOD hash — the output is purely a function of the
+  //            fetcher inputs (URL/rev/etc.).
+  //
+  // We deliberately do *not* pass `--eval-system <pkgSystem>`. Doing so
+  // sets `builtins.currentSystem` to the package's system (e.g.
+  // `x86_64-darwin`), which then makes the expression's
+  // `flake.inputs.nixpkgs.legacyPackages.${builtins.currentSystem}` resolve
+  // to the *package's* pkgs — and re-instantiating the fetcher there
+  // produces a darwin derivation that the linux runner refuses to build
+  // ("platform mismatch"). Without `--eval-system`, `currentSystem`
+  // correctly reports the runner's actual system, runnerPkgs is the
+  // runner's pkgs, and the fetcher runs natively. The FOD hash is platform-
+  // agnostic regardless.
   const cmd =
     `nix build --no-link ` +
     `--extra-experimental-features 'nix-command flakes' ` +
-    `--eval-system ${pkgSystem} ` +
     `--impure ` +
     `--expr ${shellQuote(oneLine)}`;
 


### PR DESCRIPTION
## Summary

- Removes `--eval-system <pkgSystem>` from the prefetch `nix build` command. With it set, `builtins.currentSystem` resolved to the package's system (e.g. `x86_64-darwin`), then `flake.inputs.nixpkgs.legacyPackages.${builtins.currentSystem}` resolved to the *darwin* pkgs, then `runnerPkgs.fetchurl` produced a darwin derivation that the linux runner refused to build ("platform mismatch").
- Without `--eval-system`, `currentSystem` correctly reports the runner's own system, `runnerPkgs` is the runner's pkgs, and the fetcher executes natively. FOD hashes are platform-agnostic regardless.
- `pkgSystem` is kept as a parameter purely to namespace the prefetch cache.
- Surfaces the *real* underlying error (e.g. 404 when upstream drops a release asset) instead of a confusing "platform mismatch" wall of nix output.

## Test plan

- [x] `vitest lib/modules/manager/nix-update/` (209 tests pass)
- [x] prettier / oxlint / biome clean
- [ ] Verify against `frostplexx/nixkit` `skhd_zig` x86_64-darwin → expect a clean 404 surfaced (upstream dropped that variant in v0.0.61)
- [ ] Verify against `frostplexx/nixkit` `skhd_zig` aarch64-darwin → expect a successful prefetch + version bump