### PR TITLE
fix(manager/nix-update): reproduce pnpmDeps faithfully

### DIFF
--- a/lib/modules/manager/nix-update/expr.spec.ts
+++ b/lib/modules/manager/nix-update/expr.spec.ts
@@ -129,6 +129,12 @@ describe('modules/manager/nix-update/expr', () => {
       expect(e).toContain('fetchNpmDeps');
       expect(e).toContain('name = "foo-1.0-npm-deps"');
     });
+    it('pnpm: uses fetchPnpmDeps, not the deprecated pnpm.fetchDeps', () => {
+      const e = exprForPnpmDeps(FLAKE, VEND, 'sha256');
+      expect(e).toContain('runnerPkgs.fetchPnpmDeps');
+      // pnpm.fetchDeps force-overrides the pnpm argument with its own version.
+      expect(e).not.toContain('pnpm.fetchDeps');
+    });
     it('pnpm: includes fetcherVersion when set', () => {
       const e = exprForPnpmDeps(
         FLAKE,
@@ -140,6 +146,48 @@ describe('modules/manager/nix-update/expr', () => {
     it('pnpm: omits fetcherVersion when not set', () => {
       const e = exprForPnpmDeps(FLAKE, VEND, 'sha256');
       expect(e).not.toContain('fetcherVersion');
+    });
+    it('pnpm: pins the package’s pnpm major', () => {
+      const e = exprForPnpmDeps(
+        FLAKE,
+        { ...VEND, pnpmVersion: '11.20.0' },
+        'sha256',
+      );
+      expect(e).toContain('pnpm = runnerPkgs.pnpm_11;');
+      // A fallback to the default pnpm would silently produce a wrong hash.
+      expect(e).not.toContain('or runnerPkgs.pnpm');
+    });
+    it('pnpm: omits the pnpm pin when the version is unusable', () => {
+      const e = exprForPnpmDeps(
+        FLAKE,
+        { ...VEND, pnpmVersion: 'unstable' },
+        'sha256',
+      );
+      expect(e).not.toContain('runnerPkgs.pnpm_');
+    });
+    it('pnpm: forwards workspaces, install flags and prePnpmInstall', () => {
+      const e = exprForPnpmDeps(
+        FLAKE,
+        {
+          ...VEND,
+          pnpmWorkspaces: ['a', 'b'],
+          pnpmInstallFlags: ['--foo'],
+          prePnpmInstall: 'pnpm config set x y',
+        },
+        'sha256',
+      );
+      expect(e).toContain('pnpmWorkspaces = [ "a" "b" ];');
+      expect(e).toContain('pnpmInstallFlags = [ "--foo" ];');
+      expect(e).toContain('prePnpmInstall = "pnpm config set x y";');
+    });
+    it('pnpm: omits empty lists rather than passing them explicitly', () => {
+      const e = exprForPnpmDeps(
+        FLAKE,
+        { ...VEND, pnpmWorkspaces: [], pnpmInstallFlags: [] },
+        'sha256',
+      );
+      expect(e).not.toContain('pnpmWorkspaces');
+      expect(e).not.toContain('pnpmInstallFlags');
     });
     it('yarn: fetchYarnDeps with yarnLock path', () => {
       const e = exprForYarnDeps(FLAKE, VEND, 'sha256');

--- a/lib/modules/manager/nix-update/expr.ts
+++ b/lib/modules/manager/nix-update/expr.ts
@@ -27,9 +27,6 @@ export interface FetcherInputs {
   format?: string;
   extension?: string;
 
-  // pnpm
-  fetcherVersion?: number;
-
   // For vendor FODs that need an externally-built src
   srcExpr?: string; // raw nix expression, e.g. a runner-side src fetcher call
 
@@ -185,8 +182,12 @@ export interface VendorInputs {
   version: string;
   // raw nix expression for src — usually a runner-side fetcher call with a known hash
   srcExpr: string;
-  // optional, fetcher-specific
+  // fetchPnpmDeps args, read off the package's own pnpmDeps derivation
   fetcherVersion?: number;
+  pnpmVersion?: string;
+  pnpmWorkspaces?: string[];
+  pnpmInstallFlags?: string[];
+  prePnpmInstall?: string;
 }
 
 // (runnerPkgs.buildGoModule { ... vendorHash = ""; }).goModules
@@ -234,22 +235,39 @@ export function exprForNpmDeps(
     }`;
 }
 
-// pnpm: pnpm.fetchDeps. fetcherVersion controls store layout (>= 8 vs older).
+// pnpm: fetchPnpmDeps. `pnpm.fetchDeps` is deprecated and, more importantly,
+// force-overrides the `pnpm` argument with its own version — so a package
+// pinning pnpm_11 could not be reproduced through it.
 export function exprForPnpmDeps(
   flakePath: string,
   v: VendorInputs,
   algo: HashAlgo,
 ): string {
-  const fv =
-    v.fetcherVersion === undefined
-      ? ''
-      : `fetcherVersion = ${nixVal(v.fetcherVersion)};`;
+  const attrs: string[] = [];
+  // No `or runnerPkgs.pnpm` fallback: a different pnpm major writes a
+  // different store layout, so guessing here would mean a silently wrong hash.
+  const major = /^(\d+)\./.exec(v.pnpmVersion ?? '')?.[1];
+  if (major) {
+    attrs.push(`pnpm = runnerPkgs.pnpm_${major};`);
+  }
+  if (v.fetcherVersion !== undefined) {
+    attrs.push(`fetcherVersion = ${nixVal(v.fetcherVersion)};`);
+  }
+  if (v.pnpmWorkspaces?.length) {
+    attrs.push(`pnpmWorkspaces = ${nixVal(v.pnpmWorkspaces)};`);
+  }
+  if (v.pnpmInstallFlags?.length) {
+    attrs.push(`pnpmInstallFlags = ${nixVal(v.pnpmInstallFlags)};`);
+  }
+  if (v.prePnpmInstall) {
+    attrs.push(`prePnpmInstall = ${nixVal(v.prePnpmInstall)};`);
+  }
   return `${preamble(flakePath)}
-    runnerPkgs.pnpm.fetchDeps {
+    runnerPkgs.fetchPnpmDeps {
       pname = ${nixVal(v.pname)};
       version = ${nixVal(v.version)};
       src = ${v.srcExpr};
-      ${fv}
+      ${attrs.join(' ')}
       ${hashPlaceholderAttr(algo)}
     }`;
 }

--- a/lib/modules/manager/nix-update/extract.ts
+++ b/lib/modules/manager/nix-update/extract.ts
@@ -39,6 +39,18 @@ builtins.foldl'
         if drv ? \${a} && builtins.isList drv.\${a} && builtins.length drv.\${a} > 0
         then discardCtx (builtins.head drv.\${a})
         else null;
+      maybeStrList = a:
+        if drv ? \${a} && builtins.isList drv.\${a}
+        then map discardCtx drv.\${a}
+        else null;
+      /* Older nixpkgs exposes fetcherVersion as the stringified env var
+         rather than through passthru; the assertions want an int. */
+      maybeInt = a:
+        let v = drv.\${a} or null; in
+        if builtins.isInt v then v
+        else if builtins.isString v && builtins.match "[0-9]+" v != null
+        then builtins.fromJSON v
+        else null;
     in {
       outputHash = discardCtx drv.outputHash;
       outputHashAlgo = drv.outputHashAlgo or "sha256";
@@ -49,11 +61,19 @@ builtins.foldl'
       leaveDotGit = maybeBool "leaveDotGit";
       deepClone = maybeBool "deepClone";
       forceFetchGit = maybeBool "forceFetchGit";
-      sparseCheckout =
-        if drv ? sparseCheckout && builtins.isList drv.sparseCheckout
-        then map discardCtx drv.sparseCheckout
-        else null;
+      sparseCheckout = maybeStrList "sparseCheckout";
       name = maybe "name";
+      /* fetchPnpmDeps args. fetcherVersion is mandatory in current nixpkgs,
+         and each of these changes the fetched store layout — so all of them
+         have to be mirrored into the runner-side rebuild. */
+      fetcherVersion = maybeInt "fetcherVersion";
+      pnpmVersion =
+        if drv ? pnpm && drv.pnpm ? version
+        then discardCtx drv.pnpm.version
+        else null;
+      pnpmWorkspaces = maybeStrList "pnpmWorkspaces";
+      pnpmInstallFlags = maybeStrList "pnpmInstallFlags";
+      prePnpmInstall = maybe "prePnpmInstall";
     };
   /* Well-known FOD attribute names. Order matters: src first, then vendor
      FODs. If a package has more than one of these, each becomes a separate
@@ -162,6 +182,13 @@ export interface FodInputs {
   forceFetchGit: boolean | null;
   sparseCheckout: string[] | null;
   name: string | null;
+  // fetchPnpmDeps args. Optional, not `| null`: package files extracted by an
+  // older Renovate can still be in the repository cache without them.
+  fetcherVersion?: number | null;
+  pnpmVersion?: string | null;
+  pnpmWorkspaces?: string[] | null;
+  pnpmInstallFlags?: string[] | null;
+  prePnpmInstall?: string | null;
 }
 
 export interface FodInfo {

--- a/lib/modules/manager/nix-update/fetchers.spec.ts
+++ b/lib/modules/manager/nix-update/fetchers.spec.ts
@@ -167,7 +167,30 @@ describe('modules/manager/nix-update/fetchers', () => {
       const c = classifyFod(fod, 'foo', '1');
       expect(c.fetcherName).toBe('pnpmDeps');
       const expr = c.buildExpr(FLAKE, '<src>');
-      expect(expr).toContain('runnerPkgs.pnpm.fetchDeps');
+      expect(expr).toContain('runnerPkgs.fetchPnpmDeps');
+    });
+
+    it('pnpmDeps forwards the fetchPnpmDeps args read off the derivation', () => {
+      const fod = makeFod(['pnpmDeps'], {
+        fetcherVersion: 4,
+        pnpmVersion: '11.20.0',
+        pnpmWorkspaces: ['pkg-a'],
+        pnpmInstallFlags: ['--no-optional'],
+        prePnpmInstall: 'pnpm config set foo bar',
+      });
+      const expr = classifyFod(fod, 'foo', '1').buildExpr(FLAKE, '<src>');
+      expect(expr).toContain('fetcherVersion = 4;');
+      expect(expr).toContain('pnpm = runnerPkgs.pnpm_11;');
+      expect(expr).toContain('pnpmWorkspaces = [ "pkg-a" ];');
+      expect(expr).toContain('pnpmInstallFlags = [ "--no-optional" ];');
+      expect(expr).toContain('prePnpmInstall = "pnpm config set foo bar";');
+    });
+
+    it('pnpmDeps tolerates a cache entry extracted before these were read', () => {
+      const fod = makeFod(['pnpmDeps'], {});
+      const expr = classifyFod(fod, 'foo', '1').buildExpr(FLAKE, '<src>');
+      expect(expr).not.toContain('fetcherVersion');
+      expect(expr).not.toContain('runnerPkgs.pnpm_');
     });
 
     it('classifies yarnOfflineCache', () => {

--- a/lib/modules/manager/nix-update/fetchers.ts
+++ b/lib/modules/manager/nix-update/fetchers.ts
@@ -85,7 +85,8 @@ export function classifyFod(
           buildExpr: (flakePath, srcExpr) =>
             exprForNpmDeps(flakePath, { ...v, srcExpr }, algo),
         };
-      case 'pnpmDeps':
+      case 'pnpmDeps': {
+        const pnpmArgs = pnpmVendorArgs(fod);
         return {
           attrPath: fod.attrPath,
           currentHash,
@@ -93,8 +94,9 @@ export function classifyFod(
           isSrc: false,
           fetcherName: 'pnpmDeps',
           buildExpr: (flakePath, srcExpr) =>
-            exprForPnpmDeps(flakePath, { ...v, srcExpr }, algo),
+            exprForPnpmDeps(flakePath, { ...v, ...pnpmArgs, srcExpr }, algo),
         };
+      }
       case 'yarnOfflineCache':
       case 'offlineCache':
         return {
@@ -204,6 +206,24 @@ export function buildKnownSrcExpr(
 }
 
 // ---------- internals ----------
+
+// The fetchPnpmDeps args extract.ts read off the package's own derivation.
+// Everything here changes the fetched store layout, so anything we drop shows
+// up as a wrong hash rather than as an error.
+function pnpmVendorArgs(fod: FodInfo): Partial<VendorInputs> {
+  const inp = fod.inputs;
+  return {
+    ...(typeof inp.fetcherVersion === 'number' && {
+      fetcherVersion: inp.fetcherVersion,
+    }),
+    ...(inp.pnpmVersion && { pnpmVersion: inp.pnpmVersion }),
+    ...(inp.pnpmWorkspaces?.length && { pnpmWorkspaces: inp.pnpmWorkspaces }),
+    ...(inp.pnpmInstallFlags?.length && {
+      pnpmInstallFlags: inp.pnpmInstallFlags,
+    }),
+    ...(inp.prePnpmInstall && { prePnpmInstall: inp.prePnpmInstall }),
+  };
+}
 
 const githubArchiveRegex = regEx(
   /^https?:\/\/github\.com\/[^/]+\/[^/]+\/archive\/[^/]+\.(?:tar\.gz|zip)$/,


### PR DESCRIPTION
## Problem

Every pnpm package failed to prefetch:

```
error: fetchPnpmDeps: `fetcherVersion` is not set, see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion.
```

`fetchPnpmDeps` has required `fetcherVersion` since nixpkgs removed versions 1 and 2. `VendorInputs.fetcherVersion` existed and `exprForPnpmDeps` emitted it when set — but nothing ever populated it, because `extract.ts`'s eval expression never read it off the derivation.

This is not cosmetic: the failure surfaces as `MANAGER_LOCKFILE_ERROR`, which aborts the **entire repository run** (`lib/workers/repository/update/branch/index.ts:691` → `lib/workers/repository/error.ts:205`). One pnpm package blocks every other branch in the repo.

## Fix

Five `fetchPnpmDeps` arguments change the fetched store layout, and all five are readable off the package's own `pnpmDeps` derivation — so read them there and mirror them into the runner-side rebuild:

| arg | why it matters |
| --- | --- |
| `fetcherVersion` | mandatory; hard error when absent |
| `pnpm` (major) | a different pnpm major writes a different store layout |
| `pnpmWorkspaces` | becomes `--filter=` flags, changes what is fetched |
| `pnpmInstallFlags` | passed to `pnpm install` |
| `prePnpmInstall` | shell hook run before install |

Anything left out shows up as a **wrong hash**, not as an error, so all five are forwarded.

Also switches `runnerPkgs.pnpm.fetchDeps` → `runnerPkgs.fetchPnpmDeps`. The former is deprecated, and more importantly it is defined as `args: fetchPnpmDeps (args // { pnpm = pnpm'; })` — it force-overrides `pnpm`, so a package pinning `pnpm_11` could not be reproduced through it at all.

The pnpm pin is emitted as `pnpm = runnerPkgs.pnpm_<major>;` with **no** `or runnerPkgs.pnpm` fallback: guessing a major would mean a silently wrong hash days later, where a missing attribute is a clear error in seconds.

## Verification

Against the real failing package (`frostplexx/nixkit`'s `renovate-jhc`, which pins `pnpm_11` and `fetcherVersion = 4`):

**Positive control** — the generated expression, with the placeholder swapped for the real hash, evaluates to a byte-identical derivation:

```
real package : /nix/store/sn2911ihq56cmp914kwvrcyzsrcdcsi1-renovate-pnpm-deps.drv
reconstructed: /nix/store/sn2911ihq56cmp914kwvrcyzsrcdcsi1-renovate-pnpm-deps.drv
```

**Negative control** — the previous expression reproduces the exact production error:

```
error: fetchPnpmDeps: `fetcherVersion` is not set, see ...
```

**Extract** — the updated eval expression was run against the real flake and returns `{"fetcherVersion":4,"pnpmVersion":"11.20.0",...}` for `pnpmDeps`.

Plus `220 passed` in `lib/modules/manager/nix-update/`, `tsc --noEmit`, `oxlint`, `biome`, `prettier` clean.

## Notes

- New `FodInputs` fields are optional rather than `| null`: package files extracted by an older Renovate can still sit in the repository cache without them. A stale entry degrades to today's behaviour instead of type-lying.
- `maybeInt` accepts a numeric string as well as an int — older nixpkgs exposes `fetcherVersion` as the stringified env var rather than through `passthru`, and the assertions want an int.
- Drops the unused `fetcherVersion` field from `FetcherInputs` (src fetchers). Nothing read it; its presence is what made this look already wired up.
- `sparseCheckout` now uses the new `maybeStrList` helper — same semantics, it was an exact duplicate of it.
- Not addressed here: `fetchNpmDeps` has similar hash-affecting args (`forceGitDeps`, `forceEmptyCache`, `makeCacheWritable`) that are equally unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGuVEVf2ooeJ2srHptGYZe