### PR TITLE
fix(manager/nix-update): revert version bump when artifact update fails

### DIFF
--- a/lib/modules/manager/nix-update/artifacts.spec.ts
+++ b/lib/modules/manager/nix-update/artifacts.spec.ts
@@ -332,6 +332,52 @@ describe('modules/manager/nix-update/artifacts', () => {
     ]);
   });
 
+  it('reverts the version bump when prefetch fails', async () => {
+    // The pre-update file is handed back alongside the error so the bump
+    // Renovate already staged does not reach the commit on its own.
+    fs.readLocalFile.mockResolvedValue('version = "1.0.0";');
+    mockExecSequence([STORE_DIR_PROBE, new Error('exec died')]);
+
+    const result = await updateArtifacts({
+      packageFileName: 'packages/foo/default.nix',
+      updatedDeps: [
+        {
+          depName: 'foo',
+          newVersion: '1.0.1',
+          managerData: {
+            attrName: 'foo',
+            system: 'x86_64-darwin',
+            pname: 'foo',
+            fods: [
+              makeFod(['src'], {
+                url: 'https://example.com/foo.tar.gz',
+                outputHashMode: 'flat',
+              }),
+            ],
+          },
+        },
+      ],
+      newPackageFileContent: 'version = "1.0.1";',
+      config,
+    });
+
+    expect(result).toEqual([
+      {
+        file: {
+          type: 'addition',
+          path: 'packages/foo/default.nix',
+          contents: 'version = "1.0.0";',
+        },
+      },
+      {
+        artifactError: {
+          fileName: 'packages/foo/default.nix',
+          stderr: expect.stringContaining('exec died'),
+        },
+      },
+    ]);
+  });
+
   it('returns null when localDir is unset', async () => {
     GlobalConfig.set({});
     const result = await updateArtifacts({
@@ -734,7 +780,13 @@ describe('modules/manager/nix-update/artifacts', () => {
       config,
     });
 
-    expect(result?.[0].artifactError?.stderr).toMatch(/Could not locate rev/);
+    // Revert first, then the error.
+    expect(result?.[0].file).toEqual({
+      type: 'addition',
+      path: 'packages/x/default.nix',
+      contents: 'unchanged',
+    });
+    expect(result?.[1].artifactError?.stderr).toMatch(/Could not locate rev/);
   });
 
   it('skips rewrite when file already has new hash (existing branch reuse)', async () => {

--- a/lib/modules/manager/nix-update/artifacts.spec.ts
+++ b/lib/modules/manager/nix-update/artifacts.spec.ts
@@ -239,6 +239,108 @@ describe('modules/manager/nix-update/artifacts', () => {
     expect(result).not.toBeNull();
   });
 
+  it('retargets a url-derived fetcher name onto the downloadUrl', async () => {
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({ modified: [], not_added: [] }),
+    );
+    fs.readLocalFile.mockResolvedValue('updated content');
+
+    const snapshots = mockExecSequence([
+      STORE_DIR_PROBE,
+      makeMismatchError(stderrWithGot(NEW_HASH)),
+    ]);
+
+    const oldUrl =
+      'https://x-r2.raycast-releases.com/Raycast_Beta_0.61.0.0_aaa_arm64.dmg';
+    const newUrl = 'https://x-r2.raycast-releases.com/Raycast_2.0.3.0_bbb.dmg';
+
+    await updateArtifacts({
+      packageFileName: 'packages/raycast-beta/default.nix',
+      updatedDeps: [
+        {
+          depName: 'raycast-beta',
+          currentValue: '0.61.0.0',
+          newVersion: '2.0.3.0',
+          downloadUrl: newUrl,
+          managerData: {
+            attrName: 'raycast-beta',
+            system: 'aarch64-darwin',
+            pname: 'raycast-beta',
+            fods: [
+              makeFod(['src'], {
+                url: oldUrl,
+                // What fetchurl derives when the package sets no `name`.
+                name: 'Raycast_Beta_0.61.0.0_aaa_arm64.dmg',
+                outputHashMode: 'flat',
+              }),
+            ],
+          },
+        },
+      ],
+      newPackageFileContent: codeBlock`{
+        src = fetchurl {
+          url = "${oldUrl}";
+          hash = "sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDO=";
+        };
+      }`,
+      config,
+    });
+
+    // Without retargeting this would be the version-swapped old basename,
+    // putting the FOD at a store path real evaluation never produces.
+    expect(snapshots[1].cmd).toContain('name = "Raycast_2.0.3.0_bbb.dmg"');
+    expect(snapshots[1].cmd).not.toContain('Raycast_Beta_2.0.3.0');
+  });
+
+  it('keeps an explicit fetcher name when downloadUrl replaces the url', async () => {
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({ modified: [], not_added: [] }),
+    );
+    fs.readLocalFile.mockResolvedValue('updated content');
+
+    const snapshots = mockExecSequence([
+      STORE_DIR_PROBE,
+      makeMismatchError(stderrWithGot(NEW_HASH)),
+    ]);
+
+    const oldUrl = 'https://example.com/dl/foo-1.0.0.dmg';
+    const newUrl = 'https://example.com/dl/foo-2.0.0-deadbeef.dmg';
+
+    await updateArtifacts({
+      packageFileName: 'packages/foo/default.nix',
+      updatedDeps: [
+        {
+          depName: 'foo',
+          currentValue: '1.0.0',
+          newVersion: '2.0.0',
+          downloadUrl: newUrl,
+          managerData: {
+            attrName: 'foo',
+            system: 'aarch64-darwin',
+            pname: 'foo',
+            fods: [
+              makeFod(['src'], {
+                url: oldUrl,
+                // Set by the package, not derived from the url.
+                name: 'foo-source.dmg',
+                outputHashMode: 'flat',
+              }),
+            ],
+          },
+        },
+      ],
+      newPackageFileContent: codeBlock`{
+        src = fetchurl {
+          url = "${oldUrl}";
+          hash = "sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDO=";
+        };
+      }`,
+      config,
+    });
+
+    expect(snapshots[1].cmd).toContain('name = "foo-source.dmg"');
+  });
+
   it('runs src first then vendor FOD', async () => {
     git.getRepoStatus.mockResolvedValue(
       partial<StatusResult>({ modified: [], not_added: [] }),

--- a/lib/modules/manager/nix-update/artifacts.ts
+++ b/lib/modules/manager/nix-update/artifacts.ts
@@ -165,6 +165,11 @@ export async function updateArtifacts({
               oldUrl,
               newUrl: downloadUrl,
             });
+            fod.inputs.name = retargetFetcherName(
+              fod.inputs.name,
+              oldUrl,
+              downloadUrl,
+            );
             fod.inputs.url = downloadUrl;
           }
           break;
@@ -442,6 +447,35 @@ function bumpFodToNewVersion(
     name = swap(name, oldDigest, newDigest);
   }
   return { ...fod, inputs: { ...fod.inputs, url, rev, name } };
+}
+
+// `fetchurl` defaults its derivation name to `baseNameOf url`, so the name
+// captured at extract time is usually the *old* URL's basename — and
+// `bumpFodToNewVersion` swapped the version into both. A downloadUrl replaces
+// the URL wholesale, which leaves that derived name stale. It is not merely
+// cosmetic: a fixed-output path is `<outputHash>-<name>`, so prefetching under
+// the stale name realises the artifact somewhere real evaluation never looks,
+// costing the substituter hit — and the build log then names a file that was
+// never fetched, which is exactly how a prefetch failure reads as the wrong URL.
+//
+// Re-derive only when the name demonstrably came from the URL. An explicit
+// `name = "..."` in the package belongs to the package, not the URL, and its
+// basename won't match — leave those untouched.
+function retargetFetcherName(
+  name: string | null,
+  oldUrl: string,
+  newUrl: string,
+): string | null {
+  if (!name || name !== urlBaseName(oldUrl)) {
+    return name;
+  }
+  return urlBaseName(newUrl);
+}
+
+// Mirrors nix's `baseNameOf`: everything after the last slash, query string
+// included — nix does no URL parsing here, and neither does fetchurl.
+function urlBaseName(url: string): string {
+  return url.slice(url.lastIndexOf('/') + 1);
 }
 
 function pickSrcExprFor(

--- a/lib/modules/manager/nix-update/artifacts.ts
+++ b/lib/modules/manager/nix-update/artifacts.ts
@@ -62,6 +62,36 @@ export async function updateArtifacts({
     return null;
   }
 
+  // Captured before we touch the file: what the package file looked like
+  // going into this update (base branch, or the existing PR branch on reuse).
+  // `abandon` below hands it back to revert a half-finished update.
+  const originalContent = await readLocalFile(packageFileName, 'utf8');
+
+  // The version bump lands in the commit whether or not this function
+  // succeeds — Renovate already has it in `updatedPackageFiles`. Bailing out
+  // with only an artifactError therefore ships a package whose `version` moved
+  // while its `src` url/hash did not: a derivation that builds green and
+  // fetches the *old* artifact. Returning the pre-update content as an
+  // artifact file undoes that — artifacts are written after package files in
+  // `commitFilesToBranch`, so the bump is overwritten and the branch ends up
+  // with no diff, to be retried on the next run.
+  function abandon(stderr: string): UpdateArtifactsResult[] {
+    const results: UpdateArtifactsResult[] = [];
+    if (originalContent && originalContent !== newPackageFileContent) {
+      results.push({
+        file: {
+          type: 'addition',
+          path: packageFileName,
+          contents: originalContent,
+        },
+      });
+    }
+    results.push({
+      artifactError: { fileName: packageFileName, stderr },
+    });
+    return results;
+  }
+
   // Write the version-bumped content first (renovate's auto-replace already
   // produced this — we just need it on disk so any same-package eval reads
   // the new version).
@@ -183,14 +213,7 @@ export async function updateArtifacts({
   // nix-build produced would be discarded by the early return at the end
   // anyway. Vendor prefetches cost minutes of runner time.
   if (errors.length) {
-    return [
-      {
-        artifactError: {
-          fileName: packageFileName,
-          stderr: errors.map((e) => e.stderr).join('\n'),
-        },
-      },
-    ];
+    return abandon(errors.map((e) => e.stderr).join('\n'));
   }
 
   // Checked once per package rather than per FOD: it is an infrastructure
@@ -199,14 +222,7 @@ export async function updateArtifacts({
     await assertSubstitutableStore(config.constraints?.nix);
   } catch (err) {
     logger.warn({ err, attrName }, 'nix-update: unusable nix store');
-    return [
-      {
-        artifactError: {
-          fileName: packageFileName,
-          stderr: err instanceof Error ? err.message : String(err),
-        },
-      },
-    ];
+    return abandon(err instanceof Error ? err.message : String(err));
   }
 
   // Classify all FODs. Hard-fail surface area is the classifier — anything
@@ -292,14 +308,7 @@ export async function updateArtifacts({
 
   if (errors.length) {
     // One artifactError summarises all per-FOD failures for this package.
-    return [
-      {
-        artifactError: {
-          fileName: packageFileName,
-          stderr: errors.map((e) => e.stderr).join('\n'),
-        },
-      },
-    ];
+    return abandon(errors.map((e) => e.stderr).join('\n'));
   }
 
   // Success: write the rewritten file (if changed), pick up any side-effect


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
